### PR TITLE
update cockroach/roachpb package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	// TODO(kaneda): Add a commandline flag for specifying a target type.
-	targetPkg := "github.com/cockroachdb/cockroach/roachpb"
+	targetPkg := "github.com/cockroachdb/cockroach/pkg/roachpb"
 	targetTypeName := "Error"
 	if err := returncheck.Run(gotool.ImportPaths(os.Args[1:]), targetPkg, targetTypeName); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
cockroach moved all its packages under the `pkg` prefix to make it easier to operate on them when other code was also in the repo (like `vendor`)